### PR TITLE
display code should work better now

### DIFF
--- a/display.py
+++ b/display.py
@@ -1,7 +1,7 @@
 import pygame
 
-W, H = 1400, 800
-w, h = W/4, H/4
+INIT_SCREEN_SIZE  = (1400,800)
+SCALE = 4
 
 class Display:
 
@@ -13,12 +13,25 @@ class Display:
     
 
         Display.screen = pygame.display.set_mode(
-            size = ( W, H ), 
+            size = INIT_SCREEN_SIZE, 
             flags = pygame.RESIZABLE,
             depth = 32
         )
+
+        if Display.screen.get_size() != INIT_SCREEN_SIZE:
+            print("Warning: requested screen size was {0}, but it ended up being {1}".format( INIT_SCREEN_SIZE, Display.screen.get_size() ))
+        
         pygame.display.set_caption("Survival")
-        Display.view_port = pygame.Surface( ( w, h ) )
+        
+        Display.refresh_view_port_size()
+
+
+    def refresh_view_port_size():
+        Display.view_port = pygame.Surface( Display.get_the_view_port_size_based_on_screen_size() )
+
+
+    def get_the_view_port_size_based_on_screen_size():
+        return [ Display.screen.get_size()[i] / SCALE for i in range(2) ]
 
 
     def sync_view_port_to_screen():
@@ -33,7 +46,6 @@ class Display:
 
 
     def on_resize(size):
-        W,H = size
-        Display.view_port = pygame.Surface( ( w, h ) )
+        Display.refresh_view_port_size()
 
 


### PR DESCRIPTION
I think what happen was when the resolution got too big for your screen your OS change the screen size which made scaling "out of sync".

I added this code to see if we can detect when a screen size was changed by OS. So if you try a big screen resolution let us see if you see this message. If you want

if Display.screen.get_size() != INIT_SCREEN_SIZE:
            print("Warning: requested screen size was {0}, but it ended up being {1}".format( INIT_SCREEN_SIZE, Display.screen.get_size() )